### PR TITLE
Integration of the wsg 50 end effector

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ source ~/.bashrc
 To start the DIMR-KUKA project in simulation, type the following command. An RSI simulator is started in the background to simulate the true response of the KRC4 via the RSI module.
 
 ```bash
-roslaunch dimr_kuka dimr_kuka.launch sim:=true
+roslaunch dimr_kuka dimr_kuka.launch sim:=true gripper:=false
 ```
 
 ### Real
@@ -114,21 +114,25 @@ Nmap done: 256 IP addresses (3 hosts up) scanned in 16.12 seconds
 
 You can then run the command for the kuka. You will then have access to rviz to control it.
 ```bash
-roslaunch dimr_kuka dimr_kuka.launch sim:=false mode:=eki 
+roslaunch dimr_kuka dimr_kuka.launch sim:=false mode:=eki gripper:=false
 ```
 
 
-To use the effector, it is first necessary to change the connection ip in the ros package. Open with your favorite editor the file: `~/catkin_ws/src/wsg50-ros-pkg/wsg_50_driver/launch/wsg_50_tcp.launch` and replace line 5 with the line below
+🦾 To use the effector, it is first necessary to change the connection ip in the ros package. Open with your favorite editor the file: `~/catkin_ws/src/wsg50-ros-pkg/wsg_50_driver/launch/wsg_50_tcp.launch` and replace line 5 with the line below
 
 ```xml
 	<param name="ip" type="string" value="192.168.250.22"/>
 ```
 
-Once registered you can run the following command to take control of the effector. Then open a browser and go to `192.168.250.22`.
+Once registered you can run the following command to take control of the effector.
 
 ```bash
-roslaunch wsg_50_driver wsg_50_tcp.launch     
+roslaunch dimr_kuka dimr_kuka.launch sim:=false mode:=eki gripper:=true   
 ```
+
+🔧 The gripper services then start automatically, you can test the operation of the gripper with the command `rosservice call /wsg_50_driver/move 50 50`. If it moves everything is normal. If it responds with a 255 error then go to the `192.168.250.22` tab *manual control* and click on the **home** button you can then use the effector directly with ROS.
+
+
 
 ### Ronoco
 

--- a/config/kinematics.yaml
+++ b/config/kinematics.yaml
@@ -2,3 +2,8 @@ manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
+
+manipulator_wsg_50:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005

--- a/config/kuka_kr6r900sixx.srdf
+++ b/config/kuka_kr6r900sixx.srdf
@@ -10,27 +10,35 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="tool0"/>
+    </group>
+    <group name="manipulator_wsg_50">
+        <chain base_link="base_link" tip_link="wsg_50_joint_finger_center"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">
-        <joint name="joint_a1" value="0" />
-        <joint name="joint_a2" value="0" />
-        <joint name="joint_a3" value="0" />
-        <joint name="joint_a4" value="0" />
-        <joint name="joint_a5" value="0" />
-        <joint name="joint_a6" value="0" />
+        <joint name="joint_a1" value="0"/>
+        <joint name="joint_a2" value="0"/>
+        <joint name="joint_a3" value="0"/>
+        <joint name="joint_a4" value="0"/>
+        <joint name="joint_a5" value="0"/>
+        <joint name="joint_a6" value="0"/>
     </group_state>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="FixedBase" type="fixed" parent_frame="world" child_link="base_link" />
+    <virtual_joint name="FixedBase" type="fixed" parent_frame="world" child_link="base_link"/>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
-    <disable_collisions link1="base_link" link2="link_1" reason="Adjacent" />
-    <disable_collisions link1="link_1" link2="link_2" reason="Adjacent" />
-    <disable_collisions link1="link_1" link2="link_3" reason="Never" />
-    <disable_collisions link1="link_2" link2="link_3" reason="Adjacent" />
-    <disable_collisions link1="link_3" link2="link_4" reason="Adjacent" />
-    <disable_collisions link1="link_3" link2="link_5" reason="Never" />
-    <disable_collisions link1="link_3" link2="link_6" reason="Never" />
-    <disable_collisions link1="link_4" link2="link_5" reason="Adjacent" />
-    <disable_collisions link1="link_5" link2="link_6" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="link_1" reason="Adjacent"/>
+    <disable_collisions link1="link_1" link2="link_2" reason="Adjacent"/>
+    <disable_collisions link1="link_1" link2="link_3" reason="Never"/>
+    <disable_collisions link1="link_2" link2="link_3" reason="Adjacent"/>
+    <disable_collisions link1="link_3" link2="link_4" reason="Adjacent"/>
+    <disable_collisions link1="link_3" link2="link_5" reason="Never"/>
+    <disable_collisions link1="link_3" link2="link_6" reason="Never"/>
+    <disable_collisions link1="link_4" link2="link_5" reason="Adjacent"/>
+    <disable_collisions link1="link_5" link2="link_6" reason="Adjacent"/>
+    <disable_collisions link1="link_6" link2="tool0" reason="Adjacent"/>
+    <disable_collisions link1="tool0" link2="wsg_50_gripper_left" reason="Adjacent"/>
+    <disable_collisions link1="tool0" link2="wsg_50_gripper_right" reason="Adjacent"/>
+    <disable_collisions link1="wsg_50_gripper_right" link2="wsg_50_finger_right" reason="Adjacent"/>
+    <disable_collisions link1="wsg_50_gripper_left" link2="wsg_50_finger_left" reason="Adjacent"/>
 </robot>

--- a/launch/dimr_kuka.launch
+++ b/launch/dimr_kuka.launch
@@ -2,13 +2,15 @@
 <launch>
 
     <!-- Simulation ou pas, vrai par défaut -->
-    <arg name="sim" default="true" /> <!-- true ou false -->
-    <arg name="mode" default="rsi" /> <!-- rsi ou eki -->
+    <arg name="sim" default="true"/> <!-- true ou false -->
+    <arg name="gripper" default="false"/> <!-- true ou false -->
+    <arg name="mode" default="rsi"/> <!-- rsi ou eki -->
 
     <!-- Moveit, rviz, simulateur (ou lien RSI) -->
     <include file="$(find dimr_kuka)/launch/moveit_rviz_planning_execution.launch">
-      <arg name="sim" value="$(arg sim)"/>
-      <arg name="mode" default="$(arg mode)" />
+        <arg name="sim" value="$(arg sim)"/>
+        <arg name="mode" default="$(arg mode)"/>
+        <arg name="gripper" value="$(arg gripper)"/> <!-- true ou false -->
     </include>
 
     <!-- Launch main_ihm.py interface -->

--- a/launch/moveit/moveit.rviz
+++ b/launch/moveit/moveit.rviz
@@ -11,7 +11,7 @@ Panels:
         - /MotionPlanning1/Planning Metrics1
         - /MotionPlanning1/Planned Path1
       Splitter Ratio: 0.5170649886131287
-    Tree Height: 140
+    Tree Height: 463
   - Class: rviz/Help
     Name: Help
   - Class: rviz/Views
@@ -52,7 +52,6 @@ Visualization Manager:
       MoveIt_Allow_External_Program: false
       MoveIt_Allow_Replanning: true
       MoveIt_Allow_Sensor_Positioning: false
-      MoveIt_Goal_Tolerance: 0.03
       MoveIt_Planning_Attempts: 10
       MoveIt_Planning_Time: 5
       MoveIt_Use_Cartesian_Path: true
@@ -121,11 +120,36 @@ Visualization Manager:
             Alpha: 1
             Show Axes: false
             Show Trail: false
+            Value: true
+          wsg_50_finger_left:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_finger_right:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_gripper_left:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_gripper_right:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_joint_finger_center:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
         Show Robot Collision: false
-        Show Robot Visual: false
+        Show Robot Visual: true
         Show Trail: false
         State Display Time: 0.05 s
         Trail Step Size: 1
@@ -144,9 +168,9 @@ Visualization Manager:
         Interactive Marker Size: 0
         Joint Violation Color: 255; 0; 255
         Planning Group: manipulator
-        Query Goal State: false
+        Query Goal State: true
         Query Start State: false
-        Show Workspace: true
+        Show Workspace: false
         Start State Alpha: 1
         Start State Color: 0; 255; 0
       Planning Scene Topic: /move_group/monitored_planning_scene
@@ -209,6 +233,31 @@ Visualization Manager:
             Alpha: 1
             Show Axes: false
             Show Trail: false
+            Value: true
+          wsg_50_finger_left:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_finger_right:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_gripper_left:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_gripper_right:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wsg_50_joint_finger_center:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
         Robot Alpha: 0.8999999761581421
         Show Robot Collision: false
         Show Robot Visual: true
@@ -219,6 +268,7 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: true
+      Marker Alpha: 1
       Marker Scale: 1
       Name: TF
       Show Arrows: true
@@ -244,16 +294,17 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/XYOrbit
-      Distance: 2.7615880966186523
+      Distance: 3.4641361236572266
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
+      Field of View: 0.7853981852531433
       Focal Point:
         X: 0.20710361003875732
         Y: 0.5478169918060303
-        Z: -1.1920928955078125e-7
+        Z: -1.1920928955078125e-07
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
@@ -261,13 +312,12 @@ Visualization Manager:
       Near Clip Distance: 0.009999999776482582
       Pitch: 0.029798511415719986
       Target Frame: base_link
-      Value: XYOrbit (rviz)
       Yaw: 5.366696834564209
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 713
+  Height: 1726
   Help:
     collapsed: false
   Hide Left Dock: false
@@ -276,9 +326,9 @@ Window Geometry:
     collapsed: false
   MotionPlanning - Trajectory Slider:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000100000000000002950000026ffc0200000007fb000000100044006900730070006c006100790073010000003d000000c9000000c900fffffffb0000000800480065006c00700000000342000000bb0000006e00fffffffb0000000a0056006900650077007300000003b0000000b0000000a400fffffffb0000000c00430061006d00650072006100000002ff000001610000000000000000fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e006701000001fc000001cb0000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000004100fffffffb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e0067010000010c000001a00000019b00ffffff000002880000026f00000001000000020000000100000002fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000001000000000000036a0000062cfc0200000007fb000000100044006900730070006c0061007900730100000069000002330000017800fffffffb0000000800480065006c00700000000342000000bb000000cf00fffffffb0000000a0056006900650077007300000003b0000000b00000012300fffffffb0000000c00430061006d00650072006100000002ff000001610000000000000000fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e006701000001fc000001cb0000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000002100000021fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006701000002a8000003ed0000028e00ffffff0000090a0000062c00000001000000020000000100000002fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Views:
     collapsed: false
-  Width: 1315
-  X: 51
-  Y: 27
+  Width: 3200
+  X: 0
+  Y: 0

--- a/launch/moveit_rviz_planning_execution.launch
+++ b/launch/moveit_rviz_planning_execution.launch
@@ -7,7 +7,7 @@
     <!-- https://github.com/gavanderhoorn/kuka_experimental/tree/kr6r900sixx_moveit_rsi_convenience -->
     <!-- Ils  ont été modifiés dans le cadre de ce projet DIMR, voir dossier "moveit/"              -->
     <!-- Théoriquement, si RSI fonctionne sur le krc4, une connexion direct peut être établie       -->
-    <!-- avec la commande suivante, en utilisant le package moveit pour la planification de traj:   --> 
+    <!-- avec la commande suivante, en utilisant le package moveit pour la planification de traj:   -->
     <!-- roslaunch dimr_kuka test_moveit_rviz_planning_execution.launch sim:=false                  -->
     <!-- ========================================================================================== -->
 
@@ -18,20 +18,21 @@
 
 
     <!-- Simulation ou pas, vrai par défaut -->
-    <arg name="sim" default="true" />
-    <arg name="mode" default="rsi" />
+    <arg name="sim" default="true"/>
+    <arg name="mode" default="rsi"/>
+    <arg name="gripper" default="false"/>
 
     <!-- The name of the parameter under which the URDF is loaded -->
     <arg name="robot_description" default="robot_description"/>
 
     <!-- By default, we do not start a database (it can be large) -->
-    <arg name="db" default="false" doc="Start the MoveIt database" />
+    <arg name="db" default="false" doc="Start the MoveIt database"/>
     <!-- Allow user to specify database location -->
-    <arg name="db_path" default="$(find dimr_kuka)/default_warehouse_mongo_db" doc="Path to database files" />
+    <arg name="db_path" default="$(find dimr_kuka)/default_warehouse_mongo_db" doc="Path to database files"/>
 
     <!-- name of the ros_control controllers (see below) -->
-    <arg name="js_ctrlr" value="joint_state_controller" />
-    <arg name="pos_ctrlr_name" value="position_trajectory_controller" />
+    <arg name="js_ctrlr" value="joint_state_controller"/>
+    <arg name="pos_ctrlr_name" value="position_trajectory_controller"/>
 
 
     <!-- ======================================== -->
@@ -44,12 +45,12 @@
     <!-- On choisit le bon fichier de paramètres -->
     <!-- Si on est en simu, on utilise les params de simu RSI -->
     <group if="$(arg sim)">
-    	<rosparam file="$(find dimr_kuka)/config/params_sim.yaml" command="load"/>
+        <rosparam file="$(find dimr_kuka)/config/params_sim.yaml" command="load"/>
     </group>
     <!-- Sinon, sélection du bon fichier de param-->
     <group unless="$(arg sim)">
-	<rosparam file="$(find dimr_kuka)/config/params_rsi.yaml" command="load" if="$(eval mode == 'rsi')"/>
-	<rosparam file="$(find dimr_kuka)/config/params_eki.yaml" command="load" if="$(eval mode == 'eki')"/>
+        <rosparam file="$(find dimr_kuka)/config/params_rsi.yaml" command="load" if="$(eval mode == 'rsi')"/>
+        <rosparam file="$(find dimr_kuka)/config/params_eki.yaml" command="load" if="$(eval mode == 'eki')"/>
     </group>
 
     <!-- Load joint controller configurations from YAML file to parameter server -->
@@ -58,19 +59,29 @@
     <rosparam file="$(find dimr_kuka)/config/controller_joint_names.yaml" command="load"/>
 
     <!-- Chargement du modèle KR6 R900 -->
-    <param name="$(arg robot_description)" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+    <group if="$(arg gripper)">
+        <param name="$(arg robot_description)"
+               command="$(find xacro)/xacro '$(find kuka_kr6_wsg_50_support)/urdf/kr6r900sixx.xacro'"/>
+        <group unless="$(arg sim)">
+            <include file="$(find wsg_50_driver)/launch/wsg_50_tcp.launch"/>
+        </group>
+    </group>
+    <group unless="$(arg gripper)">
+        <param name="$(arg robot_description)"
+               command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+    </group>
 
     <!-- ... et sa sémantique associée -->
-    <param name="$(arg robot_description)_semantic" textfile="$(find dimr_kuka)/config/kuka_kr6r900sixx.srdf" />
+    <param name="$(arg robot_description)_semantic" textfile="$(find dimr_kuka)/config/kuka_kr6r900sixx.srdf"/>
 
     <!-- Load updated joint limits (override information from URDF) -->
     <group ns="$(arg robot_description)_planning">
-      <rosparam command="load" file="$(find dimr_kuka)/config/joint_limits.yaml"/>
+        <rosparam command="load" file="$(find dimr_kuka)/config/joint_limits.yaml"/>
     </group>
 
     <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
     <group ns="$(arg robot_description)_kinematics">
-      <rosparam command="load" file="$(find dimr_kuka)/config/kinematics.yaml"/>
+        <rosparam command="load" file="$(find dimr_kuka)/config/kinematics.yaml"/>
     </group>
 
 
@@ -80,53 +91,54 @@
 
     <!-- Si on est en simu, on utilise RSI -->
     <group if="$(arg sim)">
-	<!-- Start RSI interface (default) -->
-	<node name="kuka_hardware_interface" pkg="kuka_rsi_hw_interface"
-	type="kuka_hardware_interface_node" respawn="false"
-	output="screen"
-	required="true">
-	<!-- remap topics to conform to ROS-I specifications -->
-	<remap from="$(arg pos_ctrlr_name)/follow_joint_trajectory" to="/joint_trajectory_action" />
-	<remap from="$(arg pos_ctrlr_name)/state" to="/feedback_states" />
-	<remap from="$(arg pos_ctrlr_name)/command" to="/joint_path_command"/>
-	</node>
+        <!-- Start RSI interface (default) -->
+        <node name="kuka_hardware_interface" pkg="kuka_rsi_hw_interface"
+              type="kuka_hardware_interface_node" respawn="false"
+              output="screen"
+              required="true">
+            <!-- remap topics to conform to ROS-I specifications -->
+            <remap from="$(arg pos_ctrlr_name)/follow_joint_trajectory" to="/joint_trajectory_action"/>
+            <remap from="$(arg pos_ctrlr_name)/state" to="/feedback_states"/>
+            <remap from="$(arg pos_ctrlr_name)/command" to="/joint_path_command"/>
+        </node>
     </group>
 
     <!-- Sinon, sélection du bon bridge hardware (RSI ou EKI) -->
     <group unless="$(arg sim)">
-	<!-- Start RSI interface (default) -->
-	<node name="kuka_hardware_interface" pkg="kuka_rsi_hw_interface"
-	type="kuka_hardware_interface_node" respawn="false"
-	output="screen"
-	required="true"
-	if="$(eval mode == 'rsi')">
-	<!-- remap topics to conform to ROS-I specifications -->
-	<remap from="$(arg pos_ctrlr_name)/follow_joint_trajectory" to="/joint_trajectory_action" />
-	<remap from="$(arg pos_ctrlr_name)/state" to="/feedback_states" />
-	<remap from="$(arg pos_ctrlr_name)/command" to="/joint_path_command"/>
-	</node>
+        <!-- Start RSI interface (default) -->
+        <node name="kuka_hardware_interface" pkg="kuka_rsi_hw_interface"
+              type="kuka_hardware_interface_node" respawn="false"
+              output="screen"
+              required="true"
+              if="$(eval mode == 'rsi')">
+            <!-- remap topics to conform to ROS-I specifications -->
+            <remap from="$(arg pos_ctrlr_name)/follow_joint_trajectory" to="/joint_trajectory_action"/>
+            <remap from="$(arg pos_ctrlr_name)/state" to="/feedback_states"/>
+            <remap from="$(arg pos_ctrlr_name)/command" to="/joint_path_command"/>
+        </node>
 
-	<!-- Start EKI interface (mmode:=eki) -->
-	<node name="kuka_eki_hardware_interface" pkg="kuka_eki_hw_interface"
-	type="kuka_eki_hw_interface_node" respawn="false"
-	output="screen"
-	required="true"
-	if="$(eval mode == 'eki')">
-	<!-- remap topics to conform to ROS-I specifications -->
-	<remap from="$(arg pos_ctrlr_name)/follow_joint_trajectory" to="/joint_trajectory_action" />
-	<remap from="$(arg pos_ctrlr_name)/state" to="/feedback_states" />
-	<remap from="$(arg pos_ctrlr_name)/command" to="/joint_path_command"/>
-	</node>
+        <!-- Start EKI interface (mmode:=eki) -->
+        <node name="kuka_eki_hardware_interface" pkg="kuka_eki_hw_interface"
+              type="kuka_eki_hw_interface_node" respawn="false"
+              output="screen"
+              required="true"
+              if="$(eval mode == 'eki')">
+            <!-- remap topics to conform to ROS-I specifications -->
+            <remap from="$(arg pos_ctrlr_name)/follow_joint_trajectory" to="/joint_trajectory_action"/>
+            <remap from="$(arg pos_ctrlr_name)/state" to="/feedback_states"/>
+            <remap from="$(arg pos_ctrlr_name)/command" to="/joint_path_command"/>
+        </node>
     </group>
 
     <!-- Load controllers (ACTION topic) -->
     <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-        args="$(arg pos_ctrlr_name) $(arg js_ctrlr)"/>
+          args="$(arg pos_ctrlr_name) $(arg js_ctrlr)"/>
     <!-- Load robot state publisher -->
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
     <!-- Load RSI simulation node -->
-    <node name='kuka_rsi_simulator' pkg='kuka_rsi_simulator' type="kuka_rsi_simulator" args="127.0.0.1 49152" if="$(arg sim)" />
+    <node name='kuka_rsi_simulator' pkg='kuka_rsi_simulator' type="kuka_rsi_simulator" args="127.0.0.1 49152"
+          if="$(arg sim)"/>
 
 
     <!-- ======================================== -->
@@ -135,11 +147,11 @@
 
     <!-- Setup and launch moveit -->
     <include file="$(find dimr_kuka)/launch/moveit/move_group.launch.xml">
-      <arg name="publish_monitored_planning_scene" value="true" />
+        <arg name="publish_monitored_planning_scene" value="true"/>
     </include>
 
     <include file="$(find dimr_kuka)/launch/moveit/moveit_rviz.launch.xml">
-      <arg name="config" value="true"/>
+        <arg name="config" value="true"/>
     </include>
 
 </launch>

--- a/launch/moveit_rviz_planning_execution.launch
+++ b/launch/moveit_rviz_planning_execution.launch
@@ -58,7 +58,7 @@
     <rosparam file="$(find dimr_kuka)/config/controller_joint_names.yaml" command="load"/>
 
     <!-- Chargement du modèle KR6 R900 -->
-    <param name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+    <param name="$(arg robot_description)" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 
     <!-- ... et sa sémantique associée -->
     <param name="$(arg robot_description)_semantic" textfile="$(find dimr_kuka)/config/kuka_kr6r900sixx.srdf" />

--- a/launch/test_EKI.launch
+++ b/launch/test_EKI.launch
@@ -3,7 +3,7 @@
     <rosparam file="$(find dimr_kuka)/config/params_eki.yaml" command="load" />
 
     <!-- Chargement du modèle KR6 R900 -->
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+    <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 
     <!-- Load updated joint limits (override information from URDF) -->
     <group ns="robot_description_planning">


### PR DESCRIPTION
- ✨ Added new group "manipulator_wsg_50" in srdf allowing to manipulate the robot from the centre of the effector fingers.
- ✨ Added collision deletions for the effector in the srdf.
- ✨ Modified `moveit_rviz_planning_execution.launch` to include `gripper` parameter in addition to `sim`
- ✨ Changed the behaviour of `roslaunch dimr_kuka dimr.launch`:
  - The possible modes (having an effect only with real use) are `rsi` and `eki`. Only the **eki** module is functional
  - If launched with the parameters `gripper=true` and `sim=false`, the robot loaded will be the robot with the gripper. The gripper services **will not** be started
  - If started with parameters `gripper=true` and `sim=true`, the robot loaded will be the robot with the gripper. The gripper services **will** be started.
  - If run with `gripper=false` and `sim=true`, the loaded robot will be the robot without the gripper.
  - If started with `gripper=false` and `sim=false`, the loaded robot will be the robot without the gripper.
- 🐛 Fixed a bug due to the switch from melodic to noetic (use of xacro.py) deprecated
- 💄 Changed the rviz configuration file for a better use
- 📝 Documentation and redesign of the readme
